### PR TITLE
[FIX] index range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv/
+*venv/
 .vscode/
 __pycache__/
 .idea/

--- a/verify_bus.py
+++ b/verify_bus.py
@@ -30,7 +30,7 @@ def get_global_tree_leaves_with_tree_name(tree_name):
 
 # ###  Methods to get BUs ###
 def get_leaf_index_range():
-    return {'start': 0, 'end': 255}
+    return {'start': 0, 'end': 256}
 
 
 def _get_filenames_of_bus_in_order(path):


### PR DESCRIPTION
![image](https://github.com/larc-logs-transparentes/tlscripts/assets/77642873/693e6a7e-995c-4d41-aaf5-f9eaf47835f6)

![image](https://github.com/larc-logs-transparentes/tlscripts/assets/77642873/e63ffe17-57a8-41a1-9c5a-6218b2704858)

Para encontrar, verifiquei o hash das folhas que estão sendo inseridas na função "_build_tree_continuously()" e fui comparando com o hash do bu no campo "merkletree_leaf" no mock. Percebi então que o último BU não estava sendo usado, assim, somei um ao range de index, e funcionou :smiley: 